### PR TITLE
Added support for multiple players

### DIFF
--- a/CoopMinesweeper/wwwroot/src/client.ts
+++ b/CoopMinesweeper/wwwroot/src/client.ts
@@ -42,7 +42,7 @@ clientPeer.on("data", (data: any): void => {
     } else if (serverDataObject.serverEventType === ServerEventType.LatencyResponse) {
         Helpers.processLatency(serverDataObject.stamp);
     } else if (serverDataObject.serverEventType === ServerEventType.Move) {
-        Renderer.drawMouse(serverDataObject.mousePosition);
+        Renderer.drawMouse(serverDataObject.mousePosition, serverDataObject.playerId!);
     } else if (serverDataObject.serverEventType === ServerEventType.Game) {
         ClientHelper.handleGame(serverDataObject.affectedFields, serverDataObject.flagsLeft);
     } else if (serverDataObject.serverEventType === ServerEventType.GameWon) {
@@ -92,7 +92,7 @@ clientSignalrConnection.onclose((error?: Error): void => {
 
 otherMouseCanvas.addEventListener("mousemove", (e: MouseEvent): void => {
     const mousePosition: MousePosition = Helpers.getMousePosition(otherMouseCanvas, e);
-    clientPeer.send(JSON.stringify(new ClientDataObject(ClientEventType.Move, mousePosition)));
+    clientPeer.send(JSON.stringify(new ClientDataObject(ClientEventType.Move, mousePosition, playerId)));
 
     const field: Field = FieldHelper.getField(mousePosition.x, mousePosition.y);
     Renderer.renderMouseMove(field);
@@ -106,7 +106,7 @@ otherMouseCanvas.addEventListener("click", (e: MouseEvent): void => {
         return;
     }
 
-    clientPeer.send(JSON.stringify(new ClientDataObject(ClientEventType.Click, mousePosition)));
+    clientPeer.send(JSON.stringify(new ClientDataObject(ClientEventType.Click, mousePosition, playerId)));
 });
 
 otherMouseCanvas.addEventListener("contextmenu", (e: MouseEvent): void => {
@@ -118,7 +118,7 @@ otherMouseCanvas.addEventListener("contextmenu", (e: MouseEvent): void => {
         return;
     }
 
-    clientPeer.send(JSON.stringify(new ClientDataObject(ClientEventType.Flag, mousePosition)));
+    clientPeer.send(JSON.stringify(new ClientDataObject(ClientEventType.Flag, mousePosition, playerId)));
 });
 
 // #endregion

--- a/CoopMinesweeper/wwwroot/src/globals.ts
+++ b/CoopMinesweeper/wwwroot/src/globals.ts
@@ -17,6 +17,8 @@ const debugSimplePeer: boolean = false;
 
 let revealedFields: number = 0;
 
+const playerId = Math.floor(Math.random() * 10000);
+
 // #endregion Game properties
 
 // #region Html globals

--- a/CoopMinesweeper/wwwroot/src/host.ts
+++ b/CoopMinesweeper/wwwroot/src/host.ts
@@ -1,19 +1,9 @@
 Renderer.drawBackground();
 FieldHelper.initializeFields();
 Helpers.scrollIntoView();
-
-let peer: SimplePeer = new SimplePeer({ initiator: true, trickle: false, config: { iceServers: [{ urls: 'stun:stun.l.google.com:19302' }, { urls: 'stun:global.stun.twilio.com:3478' }] } });
-let signalrConnection: signalR = new signalR.HubConnectionBuilder().withUrl(baseSignalrUrl + "/gameHub", { logger: signalR.LogLevel.None }).build();
+let peers: SimplePeer[] = [];
+let signalrConnection: signalR = new signalR.HubConnectionBuilder().withUrl(baseSignalrUrl + "/gameHub", {logger: signalR.LogLevel.None}).build();
 signalrConnection.serverTimeoutInMilliseconds = 300000; // 5 minutes
-
-if (debugSimplePeer) {
-    const originalDebug: any = peer._debug;
-    peer._debug = function (): void {
-        const self: SimplePeer = this;
-        console.log(arguments);
-        originalDebug.apply(self, arguments);
-    };
-}
 
 let hostSignal: string;
 let gameStarted: boolean = false;
@@ -21,82 +11,99 @@ let newGameId: string;
 
 overlayStatus.innerText = "Waiting for signal...";
 
-// #region SimplePeer
-
-peer.on("signal", (data: any): void => {
-    hostSignal = JSON.stringify(data);
-
-    overlayStatus.innerText = "Signal received successfully, connecting to server...";
-
-    signalrConnection.start().then(() => {
-        overlayStatus.innerText = "Connected to server successfully, creating game...";
-
-        signalrConnection.invoke("CreateGame").then((gameId: string) => {
-            newGameId = gameId;
-            gameIdText.innerText = `Game Id: ${gameId}`;
-            overlayStatus.innerText = "Give the game id to the other player. Waiting for other player to join...";
-            copyToClipboardButton.style.display = "inline-block";
-        }).catch((err: any) => {
-            // todo: implement
-        });
-    }).catch((err: any) => {
-        // todo: implement
-    });
-});
-
-peer.on("connect", (): void => {
-    GameHelper.hideOverlay();
-    signalrConnection.stop();
-});
-
-peer.on("data", (data: any): void => {
-    const dataObject: ClientDataObject = JSON.parse(data);
-    if (dataObject.clientEventType === ClientEventType.LatencyTest) {
-        peer.send(JSON.stringify(new ServerDataObject(ServerEventType.LatencyResponse, dataObject.stamp)));
-    } else if (dataObject.clientEventType === ClientEventType.LatencyResponse) {
-        Helpers.processLatency(dataObject.stamp);
-    } else if (dataObject.clientEventType === ClientEventType.Move) {
-        Renderer.drawMouse(dataObject.mousePosition);
-    } else if (dataObject.clientEventType === ClientEventType.Click) {
-        const field: Field = FieldHelper.getField(dataObject.mousePosition.x, dataObject.mousePosition.y);
-        HostHelper.handleClick(field);
-    } else if (dataObject.clientEventType === ClientEventType.Flag) {
-        const field: Field = FieldHelper.getField(dataObject.mousePosition.x, dataObject.mousePosition.y);
-        HostHelper.handleFlag(field);
-    } else if (dataObject.clientEventType === ClientEventType.NewGame) {
-        HostHelper.startNewGame();
-    }
-});
-
-peer.on("close", () => {
-    debugger;
-    GameHelper.showEndGameScreen();
-});
-
-peer.on("error", (err: any): void => {
-    debugger;
-    if (err.code === "ERR_ICE_CONNECTION_FAILURE") {
-        return;
-    }
-
-    // todo: implement
-});
-
-// #endregion
-
 // #region SignalR
 
 signalrConnection.on("HostSignalPrompt", (clientConnectionId: string) => {
-    signalrConnection.invoke("ReceiveHostSignal", clientConnectionId, hostSignal).catch((err: any) => {
+    let peer = new SimplePeer({initiator: true, trickle: false, config: {iceServers: [{urls: 'stun:stun.l.google.com:19302'}, {urls: 'stun:global.stun.twilio.com:3478'}]}});
+
+    if (debugSimplePeer) {
+        const originalDebug: any = peer._debug;
+        peer._debug = function (): void {
+            const self: SimplePeer = this;
+            console.log(arguments);
+            originalDebug.apply(self, arguments);
+        };
+    }
+
+    peer.on("signal", (data: any): void => {
+        hostSignal = JSON.stringify(data);
+
+        overlayStatus.innerText = "Signal received successfully, connecting to server...";
+
+        signalrConnection.invoke("ReceiveHostSignal", clientConnectionId, hostSignal).catch((err: any) => {
+            // todo: implement
+        });
+    });
+
+    peer.on("connect", (): void => {
+        GameHelper.hideOverlay();
+    });
+
+    peer.on("data", (data: any): void => {
+        const dataObject: ClientDataObject = JSON.parse(data);
+        if (dataObject.clientEventType === ClientEventType.LatencyTest) {
+            peer.send(JSON.stringify(new ServerDataObject(ServerEventType.LatencyResponse, dataObject.stamp)));
+        } else if (dataObject.clientEventType === ClientEventType.LatencyResponse) {
+            Helpers.processLatency(dataObject.stamp);
+        } else if (dataObject.clientEventType === ClientEventType.Move) {
+            peers.forEach((otherPeer: SimplePeer) => {
+                if (otherPeer !== peer) {
+                    otherPeer.send(JSON.stringify(new ServerDataObject(ServerEventType.Move, new MousePosition(dataObject.mousePosition.x, dataObject.mousePosition.y), dataObject.playerId!)));
+                }
+            });
+            Renderer.drawMouse(dataObject.mousePosition, dataObject.playerId!);
+        } else if (dataObject.clientEventType === ClientEventType.Click) {
+            const field: Field = FieldHelper.getField(dataObject.mousePosition.x, dataObject.mousePosition.y);
+            HostHelper.handleClick(field);
+        } else if (dataObject.clientEventType === ClientEventType.Flag) {
+            const field: Field = FieldHelper.getField(dataObject.mousePosition.x, dataObject.mousePosition.y);
+            HostHelper.handleFlag(field);
+        } else if (dataObject.clientEventType === ClientEventType.NewGame) {
+            HostHelper.startNewGame();
+        }
+    });
+
+    peer.on("close", () => {
+        debugger;
+        GameHelper.showEndGameScreen();
+    });
+
+    peer.on("error", (err: any): void => {
+        debugger;
+        if (err.code === "ERR_ICE_CONNECTION_FAILURE") {
+            return;
+        }
+
         // todo: implement
     });
+
+    peers.push(peer);
 });
 
 signalrConnection.on("ConnectWithClient", (clientSignal: string) => {
-    peer.signal(clientSignal);
+    peers.forEach((peer: SimplePeer) => {
+        if (!peer.connected) {
+            peer.signal(clientSignal);
+        }
+    });
 });
 
 signalrConnection.onclose((error?: Error): void => {
+    // todo: implement
+});
+
+signalrConnection.start().then(() => {
+    overlayStatus.innerText = "Connected to server successfully, creating game...";
+
+    signalrConnection.invoke("CreateGame").then((gameId: string) => {
+        newGameId = gameId;
+        gameIdText.innerText = `Game Id: ${gameId}`;
+        overlayStatus.innerText = "Give the game id to the other player. Waiting for other player to join...";
+        copyToClipboardButton.style.display = "inline-block";
+    }).catch((err: any) => {
+        // todo: implement
+    });
+}).catch((err: any) => {
     // todo: implement
 });
 
@@ -106,7 +113,9 @@ signalrConnection.onclose((error?: Error): void => {
 
 otherMouseCanvas.addEventListener("mousemove", (e: MouseEvent): void => {
     const mousePosition: MousePosition = Helpers.getMousePosition(otherMouseCanvas, e);
-    peer.send(JSON.stringify(new ServerDataObject(ServerEventType.Move, mousePosition)));
+    peers.forEach((peer: SimplePeer) => {
+        peer.send(JSON.stringify(new ServerDataObject(ServerEventType.Move, mousePosition, playerId)));
+    });
 
     const field: Field = FieldHelper.getField(mousePosition.x, mousePosition.y);
     Renderer.renderMouseMove(field);
@@ -156,7 +165,9 @@ copyToClipboardButton.addEventListener("click", (): void => {
 testLatencyButton.addEventListener("click", (): void => {
     for (let i: number = 1; i < 4; i++) {
         latencyTestStamps[i] = performance.now();
-        peer.send(JSON.stringify(new ServerDataObject(ServerEventType.LatencyTest, i)));
+        peers.forEach((peer: SimplePeer) => {
+            peer.send(JSON.stringify(new ServerDataObject(ServerEventType.LatencyTest, i)));
+        });
     }
 });
 

--- a/CoopMinesweeper/wwwroot/src/hostHelper.ts
+++ b/CoopMinesweeper/wwwroot/src/hostHelper.ts
@@ -21,16 +21,22 @@ abstract class HostHelper {
             GameHelper.stopTimer();
             GameHelper.showNewGameScreen();
             affectedFields = FieldHelper.getAllBombs();
-            peer.send(JSON.stringify(new ServerDataObject(ServerEventType.GameOver, affectedFields, elapsedTime)));
+            peers.forEach((peer: SimplePeer) => {
+                peer.send(JSON.stringify(new ServerDataObject(ServerEventType.GameOver, affectedFields, elapsedTime)));
+            });
         } else {
             FieldHelper.getFieldsForReveal(field, affectedFields);
             revealedFields += affectedFields.length;
             if (revealedFields === 381) {
                 GameHelper.stopTimer();
                 GameHelper.showNewGameScreen();
-                peer.send(JSON.stringify(new ServerDataObject(ServerEventType.GameWon, affectedFields, elapsedTime)));
+                peers.forEach((peer: SimplePeer) => {
+                    peer.send(JSON.stringify(new ServerDataObject(ServerEventType.GameWon, affectedFields, elapsedTime)));
+                });
             } else {
-                peer.send(JSON.stringify(new ServerDataObject(ServerEventType.Game, affectedFields)));
+                peers.forEach((peer: SimplePeer) => {
+                    peer.send(JSON.stringify(new ServerDataObject(ServerEventType.Game, affectedFields)));
+                });
             }
         }
 
@@ -52,7 +58,9 @@ abstract class HostHelper {
         field.flag = !field.flag;
 
         const affectedFields: Field[] = [field];
-        peer.send(JSON.stringify(new ServerDataObject(ServerEventType.Game, affectedFields, flagsLeft)));
+        peers.forEach((peer: SimplePeer) => {
+            peer.send(JSON.stringify(new ServerDataObject(ServerEventType.Game, affectedFields, flagsLeft)));
+        });
         Renderer.drawAffectedFields(affectedFields);
     }
 
@@ -60,6 +68,8 @@ abstract class HostHelper {
         GameHelper.resetGame();
         gameStarted = false;
         revealedFields = 0;
-        peer.send(JSON.stringify(new ServerDataObject(ServerEventType.NewGame)));
+        peers.forEach((peer: SimplePeer) => {
+            peer.send(JSON.stringify(new ServerDataObject(ServerEventType.NewGame)));
+        });
     }
 }

--- a/CoopMinesweeper/wwwroot/src/renderer.ts
+++ b/CoopMinesweeper/wwwroot/src/renderer.ts
@@ -73,13 +73,20 @@ abstract class Renderer {
         gameCanvasContext.fillRect(field.startX, field.startY, 30, 30);
     }
 
-    public static drawMouse(position: MousePosition): void {
+    private static positions: { [key: number]: MousePosition } = {};
+
+    public static drawMouse(position: MousePosition, otherPlayerId: number): void {
         otherMouseCanvasContext.clearRect(0, 0, otherMouseCanvas.width, otherMouseCanvas.height);
 
-        const field: Field = FieldHelper.getField(position.x, position.y);
-        otherMouseCanvasContext.fillStyle = "rgba(255, 255, 255, 0.5)";
-        otherMouseCanvasContext.fillRect(field.startX, field.startY, 30, 30);
+        this.positions[otherPlayerId] = position;
+        
+        for (let key in this.positions) {
+            const position: MousePosition = this.positions[key];
+            const field: Field = FieldHelper.getField(position.x, position.y);
+            otherMouseCanvasContext.fillStyle = "rgba(255, 255, 255, 0.5)";
+            otherMouseCanvasContext.fillRect(field.startX, field.startY, 30, 30);
 
-        otherMouseCanvasContext.drawImage(cursorImage, position.x, position.y);
+            otherMouseCanvasContext.drawImage(cursorImage, position.x, position.y);
+        }
     }
 }

--- a/CoopMinesweeper/wwwroot/src/types.ts
+++ b/CoopMinesweeper/wwwroot/src/types.ts
@@ -46,14 +46,16 @@ class ClientDataObject {
     public mousePosition!: MousePosition;
     public stamp!: number;
     public clientEventType: ClientEventType;
+    public playerId?: number;
 
     constructor(clientEventType: ClientEventType.NewGame);
-    constructor(clientEventType: ClientEventType.Move | ClientEventType.Click | ClientEventType.Flag, mousePosition: MousePosition);
+    constructor(clientEventType: ClientEventType.Move | ClientEventType.Click | ClientEventType.Flag, mousePosition: MousePosition, playerId: number);
     constructor(clientEventType: ClientEventType.LatencyTest | ClientEventType.LatencyResponse, stamp: number);
-    constructor(clientEventType: ClientEventType, arg?: MousePosition | number) {
+    constructor(clientEventType: ClientEventType, arg?: MousePosition | number, playerId?: number) {
         if (arg) {
             if (arg instanceof MousePosition) {
                 this.mousePosition = arg;
+                this.playerId = playerId;
             } else {
                 this.stamp = arg;
             }
@@ -79,9 +81,10 @@ class ServerDataObject {
     public flagsLeft!: number | undefined;
     public elapsedTime!: number | undefined;
     public serverEventType: ServerEventType;
+    public playerId?: number;
 
     constructor(serverEventType: ServerEventType.NewGame);
-    constructor(serverEventType: ServerEventType.Move, mousePosition: MousePosition);
+    constructor(serverEventType: ServerEventType.Move, mousePosition: MousePosition, playerId: number);
     constructor(serverEventType: ServerEventType.LatencyTest | ServerEventType.LatencyResponse, stamp: number);
     constructor(serverEventType: ServerEventType.Game, affectedFields: Field[], flagsLeft?: number);
     constructor(serverEventType: ServerEventType.GameWon, affectedFields: Field[], elapsedTime: number);
@@ -90,6 +93,7 @@ class ServerDataObject {
         if (arg) {
             if (arg instanceof MousePosition) {
                 this.mousePosition = arg;
+                this.playerId = arg2;
             } else if (typeof arg === "number") {
                 this.stamp = arg;
             } else { // Game


### PR DESCRIPTION
If you are interested, I added support for multiple players by adding the concept of a playerId for syncing multiple mice and establishing one peer per client. Any mousemove data sent from clients to the host are relayed to all other clients.